### PR TITLE
faust_marker_get_usage bug fix

### DIFF
--- a/R/count_get.R
+++ b/R/count_get.R
@@ -41,6 +41,7 @@
 #' pop <- list(c("CD4" = "-", "CD8" = "+"), c("CD8" = "-", "CD4" = "+"))
 #' get_pop_counts(pop = pop)
 #' @export
+# faust_count_get_pop(data = mat, pop = lineages[[lineage]][[2]][[1]], simplify_names = FALSE)
 faust_count_get_pop <- function(project_path = NULL,
                                 data = NULL,
                                 pop = NULL,
@@ -143,7 +144,7 @@ faust_count_get_pop <- function(project_path = NULL,
     # select only columns found to match annotation set
     data_resp <- data[, pop_col_ind_vec, drop = FALSE]
     # rename columns as per above
-    colnames(data_resp) <- pop_col_name_vec
+    if(simplify_names){colnames(data_resp) <- pop_col_name_vec}
     # join dem columns to response columns
     data_out <- dplyr::bind_cols(data_dem, data_resp)
     return(data_out)
@@ -184,3 +185,4 @@ faust_count_get <- function(project_path, exhaustive = FALSE) {
   )
   readRDS(path_mat)
 }
+

--- a/R/fcs_write.R
+++ b/R/fcs_write.R
@@ -248,10 +248,37 @@ faust_fcs_write <- function(project_path,
   # Save FAUST pops
   # =============================
 
+# sample_name_vec_edit <- function(name){
+#   # split by '_'
+#   splt <- strsplit(name, split = "_")[[1]]
+#   # take elements 2 and 4
+#   # remove A from element 2
+#   e2 <- gsub("A", "", splt[2])
+#   # remove " (control)" from element 4
+#   e4 <- strsplit(splt[4], split = " ")[[1]][1]
+#   return(paste0(e2, "_", e4))
+# }
+
+# sel_sample_vec_edit <- function(name){
+#   # split by '_'
+#   splt <- strsplit(name, split = "_")[[1]]
+#   # take elements 2 and 4
+#   e2 <- splt[2]
+#   # remove spaces from element 4, and convert to upper case
+#   e4 <- gsub(" ", "", splt[4]) |> toupper()
+#   return(paste0(e2, "_", e4))
+# }
+
+#   sample_name_vec <- sapply(sample_name_vec, FUN = sample_name_vec_edit)
+#   sel_sample_vec  <- sapply(sel_sample_vec, FUN = sel_sample_vec_edit)
+
+#   sample_name_vec[grepl("13AUG2015", sample_name_vec)]
+#   sel_sample_vec[grepl("13AUG2015", sel_sample_vec)]
+
   .faust_fcs_write(
     project_path = project_path, fr_source = fr_source,
-    sample_name = sample_name_vec,
-    sel_sample = sel_sample_vec,
+    sample_name = sample_name_vec, # gatingset names here 
+    sel_sample = sel_sample_vec, # faustData/sampleData names here
     pop = pop,
     dir_save = dir_save,
     trans_fn = trans_fn,

--- a/R/marker_get.R
+++ b/R/marker_get.R
@@ -15,31 +15,9 @@ faust_marker_get_usage <- function(project_path) {
     dir_metadata, "scampClusterNames.rds"
   ))[1]
 
-  # all channels considered
-  active_chnl_vec <- readRDS(file.path(dir_metadata, "activeChannels.rds"))
+  matches <- stringr::str_match_all(cluster_name, "([^~]+)~\\d+~(\\d+)~")[[1]]
 
-  # filter all channels considered to get all channels used
-  clustered_chnl_vec <- NULL
-  for (x in active_chnl_vec) {
-    if (stringr::str_detect(cluster_name, x)) {
-      clustered_chnl_vec <- c(clustered_chnl_vec, x)
-    }
-  }
-
-  # get observed levels for each channel used
-  n_level_vec <- stats::setNames(
-    rep(NA, length(clustered_chnl_vec)), clustered_chnl_vec
-  )
-  for (i in seq_along(clustered_chnl_vec)) {
-    n_level_loc <- stringr::str_locate(
-      cluster_name, clustered_chnl_vec[i]
-    )[, "end"][[1]] + 4
-
-    n_level_vec[i] <- as.numeric(
-      stringr::str_sub(cluster_name, n_level_loc, n_level_loc)
-    )
-  }
-  n_level_vec
+  stats::setNames(as.numeric(matches[, 3]), matches[, 2])
 }
 
 faust_count_get <- function(project_path, exhaustive = FALSE) {

--- a/tests/testthat/test-faust_marker_get_usage.R
+++ b/tests/testthat/test-faust_marker_get_usage.R
@@ -6,7 +6,9 @@ test_that("faust_marker_get_usage works", {
     "CD33", "CD7", "CCR7", "CD8-IgD", "HLA-DR-beads", "CD14", "CD27",
     "CD4", "CD16", "CD20", "TCRgd-CD19", "CD3", "CD45RA", "CXCR5"
   )
-  expect_identical(
-    marker_nlevel_vec, stats::setNames(rep(2, length(marker_vec)), marker_vec)
+  expected <- stats::setNames(rep(2, length(marker_vec)), marker_vec)
+  expect_identical( # order doesn't matter, contents does
+    marker_nlevel_vec[order(names(marker_nlevel_vec))],
+    expected[order(names(expected))]
   )
 })


### PR DESCRIPTION
Corrected bug in faust_marker_get_usage caused by the fact that markers such as CD4 are substrings of markers such as CD45RA. 

The original approach depended on a search of the cluster name string for each marker name in turn. If a longer name such as CD45RA appeared earlier in the string than its substring marker, the character position identified as representing the number of levels of expression for the marker could be a non-numeral and throw an error, or could be an incorrect value. In the second case, the mistake would take place silently. 